### PR TITLE
GH-821: Enable build manifest generation in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import { defineConfig } from 'vite';
 export default defineConfig(({ mode }) => {
   return {
     base: mode === 'development' ? '/' : '/resume.json',
+    build: {
+      manifest: true,
+    },
     define: {
       'import.meta.env.VITE_USE_TAILORED_RESUME': JSON.stringify(
         process.env['VITE_USE_TAILORED_RESUME'] ? true : false,


### PR DESCRIPTION
this close #821
Added the `manifest` option under the `build` configuration in `vite.config.js`. This facilitates generating a build manifest, useful for module management and dependency tracking in production builds. No changes were made to existing functionality or other configurations.