### PR TITLE
GH-823: Update website URL in resume JSON file

### DIFF
--- a/public/resume.base.json
+++ b/public/resume.base.json
@@ -23,7 +23,7 @@
       }
     ],
     "summary": "Accomplished software engineer with over 7 years of experience in full-stack development, web automation, and project management. Proven track record in mentoring junior developers, optimizing team productivity, and delivering robust, high-quality solutions. Seeking a dynamic company with a clear mission and a hybrid work environment.",
-    "website": "https://neviaumi.github.io/resume.json"
+    "website": "https://neviaumi.github.io/portfolio?utm_source=resume"
   },
   "education": [
     {


### PR DESCRIPTION
this close #823
Changed the "website" field to point to the portfolio URL instead of the resume JSON URL. This ensures it directs users to the correct resource for viewing the portfolio.