### PR TITLE
GH-837: Update linkedIn icon URL for production builds

### DIFF
--- a/src/resume-html/sections/resume-about.element.js
+++ b/src/resume-html/sections/resume-about.element.js
@@ -36,8 +36,15 @@ class ResumeAboutElement extends styles.withInjectedStyles(HTMLElement)({
 
 ${resumeBasic.profiles
   .map(profile => {
+    const isDev = import.meta.env.MODE === 'development';
+
     const network = profile.network.toLowerCase();
-    const icon = network === 'github' ? githubIcon : linkedInIcon;
+    const icon =
+      network === 'github'
+        ? githubIcon
+        : isDev
+          ? linkedInIcon
+          : new URL(linkedInIcon, 'https://neviaumi.github.io/').toString();
     return `<a title="${name} ${profile.network}" href="${profile.url}" target="_blank" class='${clsx('tw-text-base tw-font-medium tw-text-primary', 'tw-items-center', 'tw-flex', 'tw-gap-2', network === 'github' ? 'tw-mb-1' : '')}'>
         <img src="${icon}" alt="${profile.network}" class="${clsx('tw-h-2.5')}"/>
         ${profile.username}


### PR DESCRIPTION
this close #837
Ensure LinkedIn icons use the correct absolute URL in production mode, while maintaining the existing behavior for development. This fixes potential issues with incorrect asset loading in production environments.