### PR TITLE
GH-883: Add web-components directory to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/playwright:v1.48.2-focal
 WORKDIR /app
 
 COPY package.json package-lock.json vite.config.js index.html tailwind.config.js postcss.config.js ./
+COPY web-components/ ./web-components
 COPY src/ ./src
 COPY public/ ./public
 


### PR DESCRIPTION
this close #883
This ensures the web-components directory is included in the Docker image during the build process. It guarantees all necessary files are available for the application to function correctly.